### PR TITLE
build(docker): initial docker images with opencv and dlib

### DIFF
--- a/opencv-dlib-nodejs/README.md
+++ b/opencv-dlib-nodejs/README.md
@@ -1,0 +1,14 @@
+# node-opencv-dlib
+
+Scripts to build image with nodejs, opencv and dlib.
+
+# Usage
+
+``` bash
+./build.sh <NODE_VERSION> <OPENCV_VERSION> <DLIB_VERSION>
+```
+
+Build OpenCV 3.4.1, node 9.9.0 and dlib 19.8:
+``` bash
+./build.sh 9.9.0 3.4.1 19.8
+```

--- a/opencv-dlib-nodejs/README.md
+++ b/opencv-dlib-nodejs/README.md
@@ -12,3 +12,22 @@ Build OpenCV 3.4.1, node 9.9.0 and dlib 19.8:
 ``` bash
 ./build.sh 9.9.0 3.4.1 19.8
 ```
+
+# Installing face-detection or opencv4nodejs
+
+1. Install build deps:
+
+1.1 Stretch
+
+```Dockerfile
+RUN apt-get install -y python build-essential 
+```
+
+1.2 Alpine
+
+```Dockerfile
+RUN apk -u --no-cache build-base python
+```
+
+2. Install face-detection or opencv4nodejs or both
+3. Delete build deps in order to reduce image size

--- a/opencv-dlib-nodejs/alpine/Dockerfile
+++ b/opencv-dlib-nodejs/alpine/Dockerfile
@@ -2,7 +2,7 @@ ARG NODE_VERSION=9.9.0
 FROM mhart/alpine-node:${NODE_VERSION} as alpine-node-opencv-dlib
 
 ARG RUNTIME_DEPS='libpng-dev libjpeg-turbo libwebp tiff openexr jasper openblas libx11-dev zlib'
-ARG BUILD_DEPS='xz wget unzip cmake build-base python linux-headers libpng-dev libjpeg-turbo-dev libwebp-dev tiff-dev openexr-dev jasper-dev openblas-dev libx11-dev zlib-dev'
+ARG BUILD_DEPS='xz wget unzip cmake build-base python linux-headers libjpeg-turbo-dev libwebp-dev tiff-dev openexr-dev jasper-dev openblas-dev zlib-dev'
 ARG OPENCV_VERSION=3.4.1
 ARG DLIB_VERSION=19.8
 ARG LIB_PREFIX='/usr/local'

--- a/opencv-dlib-nodejs/alpine/Dockerfile
+++ b/opencv-dlib-nodejs/alpine/Dockerfile
@@ -1,7 +1,7 @@
 ARG NODE_VERSION=9.9.0
 FROM mhart/alpine-node:${NODE_VERSION} as alpine-node-opencv-dlib
 
-ARG RUNTIME_DEPS='libpng libjpeg-turbo libwebp tiff openexr jasper openblas libx11 zlib'
+ARG RUNTIME_DEPS='libpng-dev libjpeg-turbo libwebp tiff openexr jasper openblas libx11-dev zlib'
 ARG BUILD_DEPS='xz wget unzip cmake build-base python linux-headers libpng-dev libjpeg-turbo-dev libwebp-dev tiff-dev openexr-dev jasper-dev openblas-dev libx11-dev zlib-dev'
 ARG OPENCV_VERSION=3.4.1
 ARG DLIB_VERSION=19.8

--- a/opencv-dlib-nodejs/alpine/Dockerfile
+++ b/opencv-dlib-nodejs/alpine/Dockerfile
@@ -1,0 +1,96 @@
+ARG NODE_VERSION=9.9.0
+FROM mhart/alpine-node:${NODE_VERSION} as alpine-node-opencv-dlib
+
+ARG RUNTIME_DEPS='libpng libjpeg-turbo libwebp tiff openexr jasper openblas libx11 zlib'
+ARG BUILD_DEPS='xz wget unzip cmake build-base python linux-headers libpng-dev libjpeg-turbo-dev libwebp-dev tiff-dev openexr-dev jasper-dev openblas-dev libx11-dev zlib-dev'
+ARG OPENCV_VERSION=3.4.1
+ARG DLIB_VERSION=19.8
+ARG LIB_PREFIX='/usr/local'
+
+ENV OPENCV_VERSION=${OPENCV_VERSION} \
+    DLIB_VERSION=${DLIB_VERSION} \
+    LIB_PREFIX=${LIB_PREFIX} \
+    OPENCV4NODEJS_DISABLE_AUTOBUILD=1 \
+    DLIB_INCLUDE_DIR='$LIB_PREFIX/include' \
+    DLIB_LIB_DIR='$LIB_PREFIX/lib'
+
+RUN apk add -u --no-cache --virtual .build-dependencies $BUILD_DEPS \
+    && wget -q https://github.com/Itseez/opencv/archive/${OPENCV_VERSION}.zip -O opencv.zip \
+    && wget -q https://github.com/Itseez/opencv_contrib/archive/${OPENCV_VERSION}.zip -O opencv_contrib.zip \
+    && wget -q https://github.com/davisking/dlib/archive/v${DLIB_VERSION}.zip -O dlib.zip \
+    && mkdir /opencv \
+    && mv opencv.zip opencv_contrib.zip /opencv \
+    && cd /opencv \
+    && unzip -qq opencv.zip \
+    && mv opencv-${OPENCV_VERSION} opencv \
+    && unzip -qq opencv_contrib.zip \
+    && mv opencv_contrib-${OPENCV_VERSION} opencv_contrib \
+    && ls -la \
+    && mkdir opencv/build \
+    && cd opencv/build \
+    && opencv_cmake_flags="-D CMAKE_BUILD_TYPE=RELEASE \
+	-D BUILD_DOCS=OFF \
+	-D BUILD_TESTS=OFF \
+	-D BUILD_PERF_TESTS=OFF \
+	-D BUILD_JAVA=OFF \
+	-D BUILD_opencv_apps=OFF \
+	-D BUILD_opencv_aruco=OFF \
+	-D BUILD_opencv_bgsegm=OFF \
+	-D BUILD_opencv_bioinspired=OFF \
+	-D BUILD_opencv_ccalib=OFF \
+	-D BUILD_opencv_datasets=OFF \
+	-D BUILD_opencv_dnn_objdetect=OFF \
+	-D BUILD_opencv_dpm=OFF \
+	-D BUILD_opencv_fuzzy=OFF \
+	-D BUILD_opencv_hfs=OFF \
+	-D BUILD_opencv_java_bindings_generator=OFF \
+	-D BUILD_opencv_js=OFF \
+    -D BUILD_opencv_img_hash=OFF \
+    -D BUILD_opencv_line_descriptor=OFF \
+    -D BUILD_opencv_optflow=OFF \
+    -D BUILD_opencv_phase_unwrapping=OFF \
+	-D BUILD_opencv_python3=OFF \
+	-D BUILD_opencv_python_bindings_generator=OFF \
+	-D BUILD_opencv_reg=OFF \
+	-D BUILD_opencv_rgbd=OFF \
+	-D BUILD_opencv_saliency=OFF \
+	-D BUILD_opencv_shape=OFF \
+	-D BUILD_opencv_stereo=OFF \
+	-D BUILD_opencv_stitching=OFF \
+	-D BUILD_opencv_structured_light=OFF \
+	-D BUILD_opencv_superres=OFF \
+	-D BUILD_opencv_surface_matching=OFF \
+	-D BUILD_opencv_ts=OFF \
+	-D BUILD_opencv_xobjdetect=OFF \
+	-D BUILD_opencv_xphoto=OFF \
+	-D CMAKE_INSTALL_PREFIX=$LIB_PREFIX \
+    -D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib/modules" \
+    && cmake $opencv_cmake_flags .. \
+    && make -j $(nproc) \
+    && cd /opencv/opencv/build \
+    && make install \
+    && cd / \
+    && rm -rf /opencv \
+    && dlib_cmake_flags="-D CMAKE_BUILD_TYPE=RELEASE \
+    -D CMAKE_INSTALL_PREFIX=$LIB_PREFIX \
+    -D DLIB_NO_GUI_SUPPORT=OFF \
+    -D DLIB_USE_BLAS=ON \
+    -D DLIB_PNG_SUPPORT=ON \
+    -D DLIB_JPEG_SUPPORT=ON \
+    -D DLIB_USE_CUDA=OFF" \
+    && unzip -qq dlib.zip \
+    && mv dlib-${DLIB_VERSION} dlib \
+    && rm dlib.zip \
+    && cd dlib \
+    && mkdir -p build \
+    && cd build \
+    && cmake $dlib_cmake_flags .. \
+    && make -j $(nproc) \
+    && cd /dlib/build \
+    && make install \
+    && cp /dlib/dlib/*.txt $LIB_PREFIX/include/dlib/ \
+    && cd / \
+    && rm -rf /dlib \
+    && apk del .build-dependencies \
+    && apk add -u --no-cache $RUNTIME_DEPS \
+    && rm -rf /var/cache/apk/* /usr/share/man /usr/local/share/man /tmp/*

--- a/opencv-dlib-nodejs/build.sh
+++ b/opencv-dlib-nodejs/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+NODE_VERSION=${1:-9.9.0}
+OPENCV_VERSION=${2:-3.4.1}
+DLIB_VERSION=${3:-19.8}
+TAG_PREFIX=justadudewhohacks
+
+for i in $(ls -d */); do
+    base=${i%%/}
+    echo "Building $base";
+    image=${TAG_PREFIX}/node-opencv-dlib:${base}
+    echo $image
+    docker build -f $base/Dockerfile -t ${image} -t ${image}-${OPENCV_VERSION} --build-arg OPENCV_VERSION=$OPENCV_VERSION --build-arg NODE_VERSION=$NODE_VERSION --build-arg DLIB_VERSION=$DLIB_VERSION $base
+    echo "Done $base";
+done

--- a/opencv-dlib-nodejs/stretch/Dockerfile
+++ b/opencv-dlib-nodejs/stretch/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch as stretch-node-opencv-dlib
 
-ARG RUNTIME_DEPS='ca-certificates libpng-dev libjpeg-dev libwebp-dev libtiff5-dev libopenexr-dev libopenblas-dev libx11-6'
-ARG BUILD_DEPS='wget unzip cmake build-essential python pkg-config libx11-dev'
+ARG RUNTIME_DEPS='ca-certificates libpng-dev libjpeg-dev libwebp-dev libtiff5-dev libopenexr-dev libopenblas-dev libx11-dev'
+ARG BUILD_DEPS='wget unzip cmake build-essential python pkg-config'
 ARG ARCH='x64'
 ARG NODE_VERSION=9.9.0
 ARG OPENCV_VERSION=3.4.1

--- a/opencv-dlib-nodejs/stretch/Dockerfile
+++ b/opencv-dlib-nodejs/stretch/Dockerfile
@@ -1,0 +1,103 @@
+FROM debian:stretch as stretch-node-opencv-dlib
+
+ARG RUNTIME_DEPS='ca-certificates libpng-dev libjpeg-dev libwebp-dev libtiff5-dev libopenexr-dev libopenblas-dev libx11-6'
+ARG BUILD_DEPS='wget unzip cmake build-essential python pkg-config libx11-dev'
+ARG ARCH='x64'
+ARG NODE_VERSION=9.9.0
+ARG OPENCV_VERSION=3.4.1
+ARG DLIB_VERSION=19.8
+ARG LIB_PREFIX='/usr/local'
+
+ENV OPENCV_VERSION=${OPENCV_VERSION} \
+    DLIB_VERSION=${DLIB_VERSION} \
+    NODE_VERSION=${NODE_VERSION} \
+    LIB_PREFIX=${LIB_PREFIX} \
+    OPENCV4NODEJS_DISABLE_AUTOBUILD=1 \
+    DLIB_INCLUDE_DIR='$LIB_PREFIX/include' \
+    DLIB_LIB_DIR='$LIB_PREFIX/lib'
+
+RUN apt-get update && apt-get install -y ${BUILD_DEPS} ${RUNTIME_DEPS} --no-install-recommends \
+    && wget https://nodejs.org/dist/v$NODE_VERSION/node-v${NODE_VERSION}-linux-$ARCH.tar.xz -O node.tar.xz \
+    && wget https://github.com/Itseez/opencv/archive/${OPENCV_VERSION}.zip -O opencv.zip \
+    && wget https://github.com/Itseez/opencv_contrib/archive/${OPENCV_VERSION}.zip -O opencv_contrib.zip \
+    && wget https://github.com/davisking/dlib/archive/v${DLIB_VERSION}.zip -O dlib.zip \
+    && tar -xJf node.tar.xz -C ${LIB_PREFIX} --strip-components=1 --no-same-owner \
+    && rm node.tar.xz \
+    && ln -s ${LIB_PREFIX}/bin/node ${LIB_PREFIX}/bin/nodejs \
+    && mkdir /opencv \
+    && mv opencv.zip opencv_contrib.zip /opencv \
+    && cd /opencv \
+    && unzip -qq opencv.zip \
+    && mv opencv-${OPENCV_VERSION} opencv \
+    && unzip -qq opencv_contrib.zip \
+    && mv opencv_contrib-${OPENCV_VERSION} opencv_contrib \
+    && ls -la \
+    && mkdir opencv/build \
+    && cd opencv/build \
+    && opencv_cmake_flags="-D CMAKE_BUILD_TYPE=RELEASE \
+	-D BUILD_DOCS=OFF \
+	-D BUILD_TESTS=OFF \
+	-D BUILD_PERF_TESTS=OFF \
+	-D BUILD_JAVA=OFF \
+	-D BUILD_opencv_apps=OFF \
+	-D BUILD_opencv_aruco=OFF \
+	-D BUILD_opencv_bgsegm=OFF \
+	-D BUILD_opencv_bioinspired=OFF \
+	-D BUILD_opencv_ccalib=OFF \
+	-D BUILD_opencv_datasets=OFF \
+	-D BUILD_opencv_dnn_objdetect=OFF \
+	-D BUILD_opencv_dpm=OFF \
+	-D BUILD_opencv_fuzzy=OFF \
+	-D BUILD_opencv_hfs=OFF \
+	-D BUILD_opencv_java_bindings_generator=OFF \
+	-D BUILD_opencv_js=OFF \
+    -D BUILD_opencv_img_hash=OFF \
+    -D BUILD_opencv_line_descriptor=OFF \
+    -D BUILD_opencv_optflow=OFF \
+    -D BUILD_opencv_phase_unwrapping=OFF \
+	-D BUILD_opencv_python3=OFF \
+	-D BUILD_opencv_python_bindings_generator=OFF \
+	-D BUILD_opencv_reg=OFF \
+	-D BUILD_opencv_rgbd=OFF \
+	-D BUILD_opencv_saliency=OFF \
+	-D BUILD_opencv_shape=OFF \
+	-D BUILD_opencv_stereo=OFF \
+	-D BUILD_opencv_stitching=OFF \
+	-D BUILD_opencv_structured_light=OFF \
+	-D BUILD_opencv_superres=OFF \
+	-D BUILD_opencv_surface_matching=OFF \
+	-D BUILD_opencv_ts=OFF \
+	-D BUILD_opencv_xobjdetect=OFF \
+	-D BUILD_opencv_xphoto=OFF \
+	-D CMAKE_INSTALL_PREFIX=$LIB_PREFIX \
+    -D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib/modules" \
+    && cmake $opencv_cmake_flags .. \
+    && make -j $(nproc) \
+    && cd /opencv/opencv/build \
+    && make install \
+    && cd / \
+    && rm -rf /opencv \
+    && dlib_cmake_flags="-D CMAKE_BUILD_TYPE=RELEASE \
+    -D CMAKE_INSTALL_PREFIX=$LIB_PREFIX \
+    -D DLIB_NO_GUI_SUPPORT=OFF \
+    -D DLIB_USE_BLAS=ON \
+    -D DLIB_PNG_SUPPORT=ON \
+    -D DLIB_JPEG_SUPPORT=ON \
+    -D DLIB_USE_CUDA=OFF" \
+    && unzip -qq dlib.zip \
+    && mv dlib-${DLIB_VERSION} dlib \
+    && rm dlib.zip \
+    && cd dlib \
+    && mkdir -p build \
+    && cd build \
+    && cmake $dlib_cmake_flags .. \
+    && make -j $(nproc) \
+    && cd /dlib/build \
+    && make install \
+    && cp /dlib/dlib/*.txt $LIB_PREFIX/include/dlib/ \
+    && cd / \
+    && rm -rf /dlib \
+    && apt-get purge -y --auto-remove $BUILD_DEPS \
+    && apt-get autoremove -y --purge \
+    && apt-get install -y $RUNTIME_DEPS --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* /usr/share/man /usr/local/share/man /tmp/*


### PR DESCRIPTION
HI. I've created few docker images with opencv and dlib.
They could be used with opencv4nodejs and face-recognition and those libs will use built-in libraries instead of compiling them from scratch.

These images are "all-in-one", with contrib, BLAS, png, jpeg and other formats support.

Also they are rather small comparing to opencv and dlib built during npm install.

```
justadudewhohacks/node-opencv-dlib   alpine 252MB
justadudewhohacks/node-opencv-dlib   stretch 554MB
``` 

There are two options: alpine (based on mhart/alpine-node and musl) stretch (based on debian-stretch and libc).

If it will be necessary those builds could be separated to smaller images like node-dlib or opencv without contrib and so on.

I haven't tested it a lot with different recognition and detection approaches with opencv4nodejs and face-recognition, but at least they installed succesfully and couple of examples work well.